### PR TITLE
Fixes for delete functionality

### DIFF
--- a/src/main/java/com/example/springboot/PostHistoryController.java
+++ b/src/main/java/com/example/springboot/PostHistoryController.java
@@ -48,9 +48,12 @@ public class PostHistoryController {
 	   	model.addAttribute("title", "Delete Page");
 	   	String pathToLogFile = env.getProperty("post.log.file");
 	   	PostLogger pl = new PostLogger(pathToLogFile);
-	   	boolean deleted = pl.deleteString(deleteText);
-       	model.addAttribute("deleted", deleted);
-		if (!deleteText.isEmpty()) model.addAttribute("deleteAttempted", true);
+		if (!deleteText.isEmpty())
+		{
+			boolean deleted = pl.deleteString(deleteText);
+			model.addAttribute("deleted", deleted);
+			model.addAttribute("deleteAttempted", true);
+		}
         return "delete";
     }
 

--- a/src/main/java/com/example/utils/PostLogger.java
+++ b/src/main/java/com/example/utils/PostLogger.java
@@ -1,10 +1,7 @@
 package com.example.utils;
 
 import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
+import java.nio.file.*;
 import java.util.ArrayDeque;
 import java.util.Iterator;
 
@@ -89,7 +86,8 @@ public class PostLogger {
 			}
 			r1.close();  r2.close();
 			fr1.close(); fr2.close();
-			return (delete && file2.renameTo(file1));
+			Files.move(Paths.get(tmpPath), Paths.get(filePath), StandardCopyOption.REPLACE_EXISTING);
+			return delete;
     	} catch (IOException e) {
 			e.printStackTrace();
             return false;

--- a/src/main/java/com/example/utils/PostLogger.java
+++ b/src/main/java/com/example/utils/PostLogger.java
@@ -78,7 +78,7 @@ public class PostLogger {
 			while (line != null) {
 				String trimmedLine = line.trim();
 				String toDeleteTrimmed = toDelete.trim();
-				if (trimmedLine.length() > 0 && !toDeleteTrimmed.equals(trimmedLine)) {
+				if (line.isEmpty() || !toDeleteTrimmed.equals(trimmedLine)) {
 					r2.write(line+System.lineSeparator());
                 }
 				else delete = true;

--- a/src/main/resources/templates/delete.html
+++ b/src/main/resources/templates/delete.html
@@ -17,7 +17,7 @@
     <form class="software_engineering_class_form layer1"
           action="/delete"
           role="delete"
-          aria-label="delete from the locat file">
+          aria-label="delete from the local file">
         <div class="delete_input">
             <span class="delete_span">
                     <input class="input_control" tabindex="2" spellcheck="false" aria-label="delete" id="text" maxlength="400" name="post_text"></span>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -17,7 +17,7 @@
     <form class="software_engineering_class_form layer1"
           action="/api"
           role="post"
-          aria-label="post in the locat file">
+          aria-label="post in the local file">
         <div class="post_input">
             <span class="post_span">
                     <input class="input_control" tabindex="2" spellcheck="false" aria-label="post" id="text" maxlength="400" name="post_input_text"></span>


### PR DESCRIPTION
1. The main issue was with File.renameTo() method which did not seem to work well for Windows. It is replaced with Files.move(), which now works well for all systems.
2. Delete is only attempted when non-empty string is specified. Previously, if no string was specified for delete, it seemed to delete the empty lines in the post_log.txt since they matched, now it does not.
3. Minor refactoring in HTML files